### PR TITLE
add json file as options support

### DIFF
--- a/src/cli/redux-generate.js
+++ b/src/cli/redux-generate.js
@@ -13,9 +13,11 @@ commander
   .version(version())
   .arguments('<blueprint> [entity name]')
   .option('-v, --verbose', 'Turn debug mode on')
+  .option('-j, --json [filename]', 'get options from json file (use [filename]:[key] to only use a specific section)')
   .description('generates code based off a blueprint')
   .action((blueprintName, entityName, command) => {
     const debug = command.verbose;
+    const json = command.json;
     const rawArgs = command.rawArgs;
     const options = minimist(rawArgs.slice(2));
 
@@ -23,10 +25,12 @@ commander
       entity: {
         name: entityName,
         options,
-        rawArgs
+        rawArgs,
+        json
       },
       debug
     };
+
     subCommand.run(blueprintName, cliArgs);
 
     /*

--- a/src/tasks/generate-from-blueprint.js
+++ b/src/tasks/generate-from-blueprint.js
@@ -1,3 +1,4 @@
+import { fileExists, readFile } from '../util/fs';
 import Task from '../models/task';
 import Blueprint from '../models/blueprint';
 
@@ -5,7 +6,33 @@ export default class extends Task {
   constructor(environment) {
     super(environment);
   }
+  // extract options from json file
+  jsonOption(jsonOption) {
+    let filename, startKey, data;
+    if(jsonOption.indexOf(':') !== -1){
+      filename = jsonOption.substring(0, jsonOption.indexOf(':'));
+      startKey = jsonOption.substring(jsonOption.indexOf(':')+1);
+    } else {
+      filename = jsonOption;
+      startKey = null;
+    }
+    if(!fileExists(filename)){
+      this.ui.writeError('JSON file does not exist: ' + filename);
+      return process.exit(1);
+    }
 
+    data = JSON.parse(readFile(filename));
+
+    if(startKey) {
+      if(!data.hasOwnProperty(startKey)){
+        this.ui.writeError('key does not exist in json: ' + startKey);
+        return process.exit(1);
+      }
+      data = data[startKey];
+    }
+
+    return data;
+  }
   // confirm blueprint exists
   // go fetch blueprint object
   // noramlize/setup args to be passed to install
@@ -17,12 +44,10 @@ export default class extends Task {
       // );
       // process.exit(1);
     // }
-
     const mainBlueprint = this.lookupBlueprint(blueprintName);
-
     const entity = {
       name: cliArgs.entity.name,
-      options: cliArgs.entity.options
+      options: Object.assign({}, (cliArgs.entity.json)?this.jsonOption(cliArgs.entity.json):{}, cliArgs.entity.options)
     };
 
     const blueprintOptions = {


### PR DESCRIPTION
Dunno if it'll interest anybody but I've added the ability to use a json file as a source for locals in addition to using the command options. useful if you want to have a configuration json for models before you create them, makes recreation easier when you do some refactoring.
