### PR TITLE
fix for issue #80

### DIFF
--- a/src/models/project-settings.js
+++ b/src/models/project-settings.js
@@ -1,5 +1,5 @@
 import path from 'path';
-import { copySync } from 'fs-extra';
+import { copySync, removeSync } from 'fs-extra';
 import jf from 'jsonfile';
 import { pwd } from 'shelljs';
 
@@ -60,7 +60,11 @@ export default class ProjectSettings {
     this.settings = json;
   }
 
+  remove() {
+    removeSync(this.settingsPath());
+  }
+
   save() {
-    jf.writeFileSync(this.settingsPath(), this.settings);
+    jf.writeFileSync(this.settingsPath(), this.settings, { spaces: 2 });
   }
 }

--- a/src/models/sub-command.js
+++ b/src/models/sub-command.js
@@ -4,8 +4,13 @@ import UI from './ui';
 class SubCommand {
   constructor(options = {}) {
     this.rawOptions = options;
-    this.settings = options.settings || new ProjectSettings();
     this.ui = options.ui || new UI();
+    try {
+      this.settings = options.settings || new ProjectSettings();
+    } catch(err) {
+      this.ui.writeError('.reduxrc is invalid.');
+      process.exit(1);
+    }
 
     this.environment = {
       ui: this.ui,

--- a/src/sub-commands/init.js
+++ b/src/sub-commands/init.js
@@ -22,10 +22,16 @@ class Init extends SubCommand {
   run() {
     this.ui.write(this.cliLogo());
     prompt.get(initPrompt, (err, result) => {
-      this.ui.writeInfo('Saving your settings...');
-      this.settings.setAllSettings(result);
-      this.settings.save();
-      this.ui.writeCreate('.reduxrc with configuration saved in project root.');
+      if (err && err.message === 'canceled') {
+        this.ui.writeLine(''); // clear to a new line 
+        this.ui.writeError('Initialization aborted. .reduxrc removed.');
+        this.settings.remove();
+      } else {
+        this.ui.writeInfo('Saving your settings...');
+        this.settings.setAllSettings(result);
+        this.settings.save();
+        this.ui.writeCreate('.reduxrc with configuration saved in project root.');
+      }
     });
   }
 

--- a/test/models/project-settings.test.js
+++ b/test/models/project-settings.test.js
@@ -3,6 +3,7 @@ import fs from 'fs';
 import fse from 'fs-extra';
 import config from 'config';
 import { fileExists } from 'util/fs';
+import { expectFileToNotExist } from '../helpers/fs-helpers';
 
 const { basePath } = config;
 const settingsPath = basePath + '/.reduxrc';
@@ -144,6 +145,14 @@ describe('ProjectSettings', () => {
       };
       settings.setAllSettings(overrideAll);
       expect(settings.getAllSettings()).to.eql(overrideAll);
+    });
+  });
+
+  describe('#remove', () => {
+    it('deletes the current settings file', () => {
+      const settings = new ProjectSettings();
+      settings.remove();
+      expectFileToNotExist(settingsPath);
     });
   });
 

--- a/test/models/sub-command.test.js
+++ b/test/models/sub-command.test.js
@@ -1,7 +1,26 @@
+import ProjectSettings from 'models/project-settings';
 import SubCommand from 'models/sub-command';
+import MockUI from '../helpers/mock-ui';
 
 describe('(Model) SubCommand', () => {
   const command = new SubCommand();
+
+  describe('constructor', () => {
+    it('should exit process when initialization of ProjectSettings fails', () => {
+      const options = {
+        ui: new MockUI()
+      };
+      const stub1 = sinon.stub(process, 'exit');
+      const stub2 = sinon.stub(ProjectSettings.prototype, 'loadSettings').throws();
+
+      const command = new SubCommand(options);
+      expect(command.ui.errors).to.match(/invalid/);
+      expect(stub1.calledWith(1));
+
+      stub1.restore();
+      stub2.restore();
+    });
+  });
 
   describe('subclass override intereface', () => {
     it('throws if subclass doesnt have run()', () => {


### PR DESCRIPTION
Fixes issue #80 

The following changes were made: 
1. Added handling for when the init prompt is prematurely aborted using Ctrl-C. Empty .reduxrc file created when the init subcommand is started is removed. 
2. Handle error thrown when an invalid .reduxrc file is being loaded. 
