### PR TITLE
Replace missing Blueprint.load(name)

### DIFF
--- a/src/models/blueprint-collection.js
+++ b/src/models/blueprint-collection.js
@@ -62,6 +62,15 @@ export default class BlueprintCollection {
       })
     );
   }
+
+  lookupAll(name) {
+    return _filter(this.all(), bp => bp.name === name);
+  }
+
+  lookup(name) {
+    return this.lookupAll(name)[0];
+  }
+
 }
 
 function validSearchDir(dir) {

--- a/src/tasks/generate-from-blueprint.js
+++ b/src/tasks/generate-from-blueprint.js
@@ -1,5 +1,4 @@
 import Task from '../models/task';
-import BlueprintCollection from '../models/blueprint-collection';
 
 export default class extends Task {
   constructor(environment) {

--- a/src/tasks/generate-from-blueprint.js
+++ b/src/tasks/generate-from-blueprint.js
@@ -1,5 +1,5 @@
 import Task from '../models/task';
-import Blueprint from '../models/blueprint';
+import BlueprintCollection from '../models/blueprint-collection';
 
 export default class extends Task {
   constructor(environment) {
@@ -37,6 +37,6 @@ export default class extends Task {
   }
 
   lookupBlueprint(name) {
-    return Blueprint.lookup(name);
+    return this.settings.blueprints.lookup(name);
   }
 }

--- a/test/fixtures/basic/files/expected-file.js
+++ b/test/fixtures/basic/files/expected-file.js
@@ -1,0 +1,1 @@
+// expected file to exist

--- a/test/fixtures/basic/index.js
+++ b/test/fixtures/basic/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+
+};

--- a/test/models/blueprint-collection.test.js
+++ b/test/models/blueprint-collection.test.js
@@ -22,9 +22,9 @@ describe('(Model) BlueprintCollection', () => {
       const blueprints = new BlueprintCollection(paths);
       const result = blueprints.all();
       expect(result).to.be.an('Array');
-      expect(result).toHaveLength(2);
+      expect(result).toHaveLength(3);
       expect(result[0].name).toEqual('basic');
-      expect(result[1].filesPath()).to.match(/fixtures\/blueprints\/duplicate/);
+      expect(result[2].filesPath()).to.match(/fixtures\/blueprints\/duplicate/);
     });
   });
 
@@ -33,9 +33,9 @@ describe('(Model) BlueprintCollection', () => {
       const blueprints = new BlueprintCollection(paths);
       const result = blueprints.generators();
       expect(result).to.be.an('Array');
-      expect(result).toHaveLength(2);
+      expect(result).toHaveLength(3);
       expect(result[0].name).toEqual('basic');
-      expect(result[1].filesPath()).to.match(/fixtures\/blueprints\/duplicate/);
+      expect(result[2].filesPath()).to.match(/fixtures\/blueprints\/duplicate/);
     });
   });
 
@@ -91,6 +91,40 @@ describe('#expandPath', () => {
     const expectedPath = basePath + path.sep + 'alfred';
     expect(resultPath).toEqual(expectedPath);
   });
+});
+
+describe('#lookupAll(name)', () => {
+  test('returns empty array if blueprint for name', () => {
+    const blueprints = new BlueprintCollection(paths);
+    expect(blueprints.lookupAll('flyingGraysons')).toEqual([]);
+  });
+  test('returns an array of blueprints matching name', () => {
+    const blueprints = new BlueprintCollection(paths);
+    const allBasic = blueprints.lookupAll('basic');
+    expect(allBasic).to.be.an('array');
+    expect(allBasic.length).toEqual(2);
+    expect(allBasic[0].name).toEqual('basic');
+    expect(allBasic[1].name).toEqual('basic');
+  });
+});
+
+
+describe('#lookup(name)', () => {
+  test('returns falsy if no blueprint for name', () => {
+    const blueprints = new BlueprintCollection(paths);
+    expect(blueprints.lookup('flyingGraysons')).to.be.falsy;
+  });
+  test('returns a blueprint matching name', () => {
+    const blueprints = new BlueprintCollection(paths);
+    expect(blueprints.lookup('basic').name).toEqual('basic');
+  });
+  test('returns the first blueprint matching name', () => {
+    const blueprints = new BlueprintCollection(paths);
+    const basic = blueprints.lookup('basic');
+    expect(basic.name).toEqual('basic');
+    expect(blueprints.lookupAll('basic')[0]).toEqual(basic);
+  });
+
 });
 
 describe('::parseBlueprintSetting', () => {

--- a/test/models/project-settings.test.js
+++ b/test/models/project-settings.test.js
@@ -59,13 +59,12 @@ describe('ProjectSettings', () => {
 
     it('collects all blueprints into an array of arrays', () => {
       // How many do we have before
-      const baseline = new ProjectSettings().blueprintChunks.length;
+      const baseline = (new ProjectSettings()).blueprintChunks.length;
 
       process.env['blueprint_config'] = 'test/fixtures/env.blueprintrc';
       const fakeArgv = { config: 'test/fixtures/argv.blueprintrc' };
       const defaultSettings = { defaultOption: true };
       const settings = new ProjectSettings(defaultSettings, fakeArgv);
-
       expect(settings.blueprintChunks.length).to.eql(baseline + 2);
       delete process.env['blueprint_config'];
     });


### PR DESCRIPTION
When refactoring to BlueprintCollection, I left out the search by name functionality.

It's replaced here.