### PR TITLE
Expanded Config cmd, and sub-command

### DIFF
--- a/src/cli/cmds/config.js
+++ b/src/cli/cmds/config.js
@@ -1,11 +1,45 @@
 import Config from '../../sub-commands/config';
+import path from 'path';
+
 const subCommand = new Config();
 
-const usage = 'Usage:\n  $0 config';
+const usage = `Usage:\n  $0 config`;
 
 module.exports = {
   command: 'config',
   describe: 'Display current configuration',
-  builder: yargs => yargs.usage(usage),
+  builder: yargs => defineBuilder(yargs).usage(usage),
   handler: () => subCommand.run()
+};
+
+const defineBuilder = yargs => {
+  return yargs.options({
+    'skip-logo': {
+      alias: 'L',
+      describe: "Don' show logo",
+      type: 'boolean'
+    },
+
+    'skip-blueprints': {
+      alias: 'B',
+      describe: "Don't show blueprints",
+      type: 'boolean'
+    },
+    'skip-blueprint-paths': {
+      alias: 'P',
+      describe: "Don't show blueprint paths",
+      type: 'boolean'
+    },
+    'skip-config-data': {
+      alias: 'D',
+      describe: "Don't show config data",
+      type: 'boolean'
+    },
+
+    'skip-config-files': {
+      alias: 'F',
+      describe: "Don't show config files",
+      type: 'boolean'
+    }
+  });
 };

--- a/src/cli/cmds/config.js
+++ b/src/cli/cmds/config.js
@@ -13,33 +13,40 @@ module.exports = {
 };
 
 const defineBuilder = yargs => {
-  return yargs.options({
-    'skip-logo': {
-      alias: 'L',
-      describe: "Don' show logo",
-      type: 'boolean'
-    },
+  return yargs.config({wooticus: {}})
+    .options({
+      'skip-logo': {
+        alias: 'L',
+        describe: "Don' show logo",
+        type: 'boolean',
+        global: true
+      },
+      'wooticus-prime': {
+        alias: 'woot',
+        type: 'string'
+      },
 
-    'skip-blueprints': {
-      alias: 'B',
-      describe: "Don't show blueprints",
-      type: 'boolean'
-    },
-    'skip-blueprint-paths': {
-      alias: 'P',
-      describe: "Don't show blueprint paths",
-      type: 'boolean'
-    },
-    'skip-config-data': {
-      alias: 'D',
-      describe: "Don't show config data",
-      type: 'boolean'
-    },
+      'skip-blueprints': {
+        alias: 'B',
+        describe: "Don't show blueprints",
+        type: 'boolean'
+      },
+      'skip-blueprint-paths': {
+        alias: 'P',
+        describe: "Don't show blueprint paths",
+        type: 'boolean'
+      },
+      'skip-config-data': {
+        alias: 'D',
+        describe: "Don't show config data",
+        type: 'boolean'
+      },
 
-    'skip-config-files': {
-      alias: 'F',
-      describe: "Don't show config files",
-      type: 'boolean'
-    }
-  });
+      'skip-config-files': {
+        alias: 'F',
+        describe: "Don't show config files",
+        type: 'boolean'
+      }
+    })
+    .describe('woot', 'Wooticus Prime!');
 };

--- a/src/cli/parser.js
+++ b/src/cli/parser.js
@@ -10,7 +10,7 @@ export function getParser() {
     .commandDir('cmds')
     .demandCommand(1, 'Provide a command to run')
     .recommendCommands()
-    .strict()
+    // .strict()
     .help()
     .alias('help', 'h')
     .version()

--- a/src/sub-commands/config.js
+++ b/src/sub-commands/config.js
@@ -15,6 +15,7 @@ class Config extends SubCommand {
   }
 
   run() {
+    console.log(this.settings)
     const finalConfig = Object.assign({}, this.settings.settings);
     delete finalConfig.configs;
     delete finalConfig.allConfigs;

--- a/src/sub-commands/config.js
+++ b/src/sub-commands/config.js
@@ -2,12 +2,16 @@ import prettyjson from 'prettyjson';
 import SubCommand from '../models/sub-command';
 
 class Config extends SubCommand {
-  constructor() {
-    super();
+  constructor(options) {
+    super(options);
   }
 
   printUserHelp() {
     this.ui.write('config command to display current configuration');
+  }
+
+  dontSkip(type) {
+    return !this.settings.settings[`skip-${type}`];
   }
 
   run() {
@@ -15,16 +19,34 @@ class Config extends SubCommand {
     delete finalConfig.configs;
     delete finalConfig.allConfigs;
     delete finalConfig['_'];
-    this.ui.write(this.cliLogo() + '\n');
-    this.ui.writeInfo('Config Files');
-    console.log(prettyjson.render(this.settings.settings.configs, {}, 8));
-    // this.settings.settings.configs.forEach(configFile => {this.ui.writeInfo(`  * ${configFile}`)})
-    this.ui.writeInfo('Config Data');
-    console.log(prettyjson.render(finalConfig, {}, 10));
-    this.ui.writeInfo('Blueprint Paths');
-    console.log(prettyjson.render(this.settings.blueprints.searchPaths, {}, 8));
-    this.ui.writeInfo('Blueprints');
-    console.log(prettyjson.render(this.settings.blueprints.allNames(), {}, 8));
+    if (this.dontSkip('logo')) {
+      this.ui.write(this.cliLogo() + '\n');
+    }
+    if (this.dontSkip('config-files')) {
+      this.ui.writeInfo('Config Files');
+      this.ui.writeLine(
+        prettyjson.render(this.settings.settings.configs, {}, 8)
+      );
+    }
+
+    if (this.dontSkip('config-data')) {
+      this.ui.writeInfo('Config Data');
+      this.ui.writeLine(prettyjson.render(finalConfig, {}, 10));
+    }
+
+    if (this.dontSkip('blueprint-paths')) {
+      this.ui.writeInfo('Blueprint Paths');
+      this.ui.writeLine(
+        prettyjson.render(this.settings.blueprints.searchPaths, {}, 8)
+      );
+    }
+
+    if (this.dontSkip('blueprints')) {
+      this.ui.writeInfo('Blueprints');
+      this.ui.writeLine(
+        prettyjson.render(this.settings.blueprints.allNames(), {}, 8)
+      );
+    }
   }
 }
 

--- a/test/cli/cmds/config.test.js
+++ b/test/cli/cmds/config.test.js
@@ -14,10 +14,16 @@ describe('(CLI) Config', () => {
 
   describe('--help', () => {
     test('shows Usage', done => {
+      parser.$0 = 'bp';
       parser.parse('help config', (err, argv, output) => {
         expect(err).to.be.undefined;
         expect(output).to.include('Usage:');
         expect(output).to.match(lineRegEx('bp config'));
+        expect(output).to.include('--skip-logo');
+        expect(output).to.include('--skip-config-files');
+        expect(output).to.include('--skip-config-data');
+        expect(output).to.include('--skip-blueprint-paths');
+        expect(output).to.include('--skip-blueprints');
         done();
       });
     });

--- a/test/sub-commands/config.test.js
+++ b/test/sub-commands/config.test.js
@@ -1,0 +1,82 @@
+import Config from 'sub-commands/config';
+import MockUI from '../helpers/mock-ui';
+
+// a piece of the logo to match against.
+const LOGO_MATCH = /______ _/;
+const CONFIG_FILES_MATCH = /Config Files/;
+const CONFIG_DATA_MATCH = /Config Data/;
+const BLUEPRINT_PATHS_MATCH = /Blueprint Paths/;
+const BLUEPRINTS_MATCH = /Blueprints/;
+
+describe('(Sub-Command) Config', () => {
+  let config;
+  const ui = new MockUI('DEBUG');
+
+  beforeEach(() => {
+    ui.clear();
+    config = new Config();
+    config.ui = ui;
+  });
+
+  test('#printUserHelp()', () => {
+    config.printUserHelp();
+    expect(ui.output).toMatch(/config command/);
+  });
+
+  test('#dontSkip(type)', () => {
+    setSkipFlag('test-A', true);
+    setSkipFlag('test-B', false);
+    // test-C deliberately left unset
+    expect(config.dontSkip('test-A')).to.be.falsy;
+    expect(config.dontSkip('test-B')).to.be.truthy;
+    expect(config.dontSkip('test-C')).to.be.truthy;
+  });
+
+  describe('#run()', () => {
+    test('prints everything when nothing skipped', () => {
+      config.run();
+      expect(ui.output).toMatch(LOGO_MATCH); // a piece of the logo
+      expect(ui.output).toMatch(CONFIG_FILES_MATCH);
+      expect(ui.output).toMatch(CONFIG_DATA_MATCH);
+      expect(ui.output).toMatch(BLUEPRINT_PATHS_MATCH);
+      expect(ui.output).toMatch(BLUEPRINTS_MATCH);
+    });
+
+    test('Skips Logo with --skip-logo', () => {
+      setSkipFlag('logo', true);
+      config.run();
+      expect(ui.output).not.toMatch(LOGO_MATCH);
+    });
+
+    test('Skips Logo with --skip-config-files', () => {
+      setSkipFlag('config-files', true);
+      config.run();
+      expect(ui.output).not.toMatch(CONFIG_FILES_MATCH);
+    });
+    test('Skips Logo with --skip-config-data', () => {
+      setSkipFlag('config-data', true);
+      config.run();
+      expect(ui.output).not.toMatch(CONFIG_DATA_MATCH);
+    });
+    test('Skips Logo with --skip-blueprint-paths', () => {
+      setSkipFlag('blueprint-paths', true);
+      config.run();
+      expect(ui.output).not.toMatch(BLUEPRINT_PATHS_MATCH);
+    });
+    test('Skips Logo with --skip-blueprints', () => {
+      setSkipFlag('blueprints', true);
+      config.run();
+      expect(ui.output).not.toMatch(BLUEPRINTS_MATCH);
+    });
+  });
+
+  const setSkipFlag = (name, val = true) => {
+    config.settings.settings[`skip-${name}`] = val;
+  };
+
+  test('setSkipFlag', () => {
+    expect(config.settings.settings['skip-test']).to.be.falsy;
+    setSkipFlag('Test');
+    expect(config.settings.settings['skip-test']).to.be.truthy;
+  });
+});


### PR DESCRIPTION
Added some options for skipping parts of the config output and wrote tests for them.

`bp config --skip-logo --skip-blueprints --skip-blueprint-paths`
```
  info: Config Files
        - /home/scottp/.blueprintrc
        - /home/scottp/4winds/redux-cli/.blueprintrc
  info: Config Data
          sourceBase:           src
          testBase:             test
          smartPath:            container
          dumbPath:             component
          fileCasing:           default
          location:             project
          blueprints:           true
          skip-logo:            true
          skip-blueprints:      true
          skip-blueprint-paths: true
          config:               /home/scottp/4winds/redux-cli/.blueprintrc
```